### PR TITLE
Fix spelling of timeout and add unit to end of timeout number.

### DIFF
--- a/lib/clusterhealth.go
+++ b/lib/clusterhealth.go
@@ -54,7 +54,7 @@ func (c *Conn) WaitForStatus(status string, timeout int, indices ...string) (Clu
 
 	body, err := c.DoCommand("GET", url, map[string]interface{}{
 		"wait_for_status": status,
-		"timout":          timeout,
+		"timeout":         fmt.Sprintf("%ds", timeout),
 	}, nil)
 
 	if err != nil {

--- a/lib/clusterhealth.go
+++ b/lib/clusterhealth.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // The cluster health API allows to get a very simple status on the health of the cluster.
@@ -43,7 +44,7 @@ func (c *Conn) Health(indices ...string) (ClusterHealthResponse, error) {
 	return retval, err
 }
 
-func (c *Conn) WaitForStatus(status string, timeout int, indices ...string) (ClusterHealthResponse, error) {
+func (c *Conn) WaitForStatus(status string, timeout time.Duration, indices ...string) (ClusterHealthResponse, error) {
 	var url string
 	var retval ClusterHealthResponse
 	if len(indices) > 0 {
@@ -54,7 +55,7 @@ func (c *Conn) WaitForStatus(status string, timeout int, indices ...string) (Clu
 
 	body, err := c.DoCommand("GET", url, map[string]interface{}{
 		"wait_for_status": status,
-		"timeout":         fmt.Sprintf("%ds", timeout),
+		"timeout":         timeout.String(),
 	}, nil)
 
 	if err != nil {


### PR DESCRIPTION
Fix bugs in the WaitForStatus method:

- Timeout misspelt so errors back saying timout does is not a param
- Timeout has not unit with it, so just added seconds as the only passable unit.

Example from https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cluster-health.html 
`GET /_cluster/health?wait_for_status=yellow&timeout=50s`

- [ ] Ran tests locally
- [x] Tested manually with reporting

![](https://media2.giphy.com/media/1BeEvRXYE5p47qDkYt/giphy.gif)